### PR TITLE
Add user login flow and admin tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,32 @@ pyinstaller --onefile --noconsole fireguard.py
 ```
 
 The compiled `fireguard.exe` automatically checks GitHub releases on startup and prompts to download a newer version if available.
+
+### Account Login
+
+FireGuard now requires users to create a free account. On first launch you will
+be prompted to register or log in. After successful authentication a license
+token is stored locally and used for all API communication.
+
+### Developer Tool EXD
+
+The EXD developer tool allows administrators to log in and monitor client activity.
+To run it locally:
+
+```bash
+python exd.py
+```
+
+The tool communicates with the backend API and requires valid admin credentials.
+
+
+### Backend API Deployment
+
+A simple Flask API implementation is provided in `server.py`. You can deploy it to [Render](https://render.com) using the included `render.yaml` configuration:
+
+```bash
+pip install -r requirements.txt
+python server.py  # local testing
+```
+
+On Render, create a new Web Service from this repo and it will automatically use `gunicorn server:app` to start the API.

--- a/exd.py
+++ b/exd.py
@@ -1,0 +1,115 @@
+# Developer tool for FireGuard - EXD
+import tkinter as tk
+import ttkbootstrap as ttkb
+from ttkbootstrap import ttk
+import requests
+from tkinter import messagebox
+
+API_URL = "https://example.com"  # TODO: replace with real API endpoint
+
+class EXDApp:
+    def __init__(self):
+        self.token = None
+        self.root = ttkb.Window(title="EXD Developer Tool")
+        self.create_login_ui()
+        self.root.mainloop()
+
+    def create_login_ui(self):
+        self.clear_root()
+        frm = ttk.Frame(self.root, padding=20)
+        frm.pack(expand=True)
+
+        ttk.Label(frm, text="Username").grid(row=0, column=0, sticky=tk.W, pady=5)
+        self.username_var = tk.StringVar()
+        ttk.Entry(frm, textvariable=self.username_var, width=30).grid(row=0, column=1)
+
+        ttk.Label(frm, text="Password").grid(row=1, column=0, sticky=tk.W, pady=5)
+        self.password_var = tk.StringVar()
+        ttk.Entry(frm, textvariable=self.password_var, show="*", width=30).grid(row=1, column=1)
+
+        ttk.Button(frm, text="Login", command=self.login).grid(row=2, column=0, columnspan=2, pady=10)
+
+    def clear_root(self):
+        for widget in self.root.winfo_children():
+            widget.destroy()
+
+    def login(self):
+        user = self.username_var.get()
+        password = self.password_var.get()
+        try:
+            resp = requests.post(f"{API_URL}/api/login", json={"username": user, "password": password}, timeout=5)
+            if resp.status_code == 200:
+                self.token = resp.json().get("token")
+                self.create_main_ui()
+            else:
+                messagebox.showerror("Login Failed", f"Status: {resp.status_code}\n{resp.text}")
+        except Exception as e:
+            messagebox.showerror("Login Error", str(e))
+
+    def create_main_ui(self):
+        self.clear_root()
+        self.root.geometry("600x400")
+        top = ttk.Frame(self.root, padding=10)
+        top.pack(fill=tk.X)
+
+        self.hwid_var = tk.StringVar()
+        ttk.Entry(top, textvariable=self.hwid_var, width=40).pack(side=tk.LEFT, padx=5)
+        ttk.Button(top, text="Fetch Logs", command=self.fetch_logs).pack(side=tk.LEFT)
+        ttk.Button(top, text="Check Status", command=self.check_status).pack(side=tk.LEFT, padx=5)
+        ttk.Button(top, text="Logout", command=self.create_login_ui).pack(side=tk.RIGHT)
+
+        self.log_text = tk.Text(self.root, state=tk.DISABLED)
+        self.log_text.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+        self.poll_logs()
+
+    def fetch_logs(self):
+        hwid = self.hwid_var.get().strip()
+        if not hwid:
+            messagebox.showerror("Error", "Enter HWID")
+            return
+        self.load_logs(hwid)
+
+    def load_logs(self, hwid: str):
+        if not self.token:
+            return
+        headers = {"Authorization": f"Bearer {self.token}"}
+        try:
+            resp = requests.get(f"{API_URL}/api/logs/{hwid}", headers=headers, timeout=5)
+            if resp.status_code == 200:
+                data = resp.json()
+                self.display_logs("\n".join(data.get("logs", [])))
+            else:
+                self.display_logs(f"Error {resp.status_code}: {resp.text}")
+        except Exception as e:
+            self.display_logs(f"Request error: {e}")
+
+    def check_status(self):
+        hwid = self.hwid_var.get().strip()
+        if not hwid or not self.token:
+            return
+        headers = {"Authorization": f"Bearer {self.token}"}
+        try:
+            resp = requests.get(f"{API_URL}/api/status", params={"hwid": hwid}, headers=headers, timeout=5)
+            if resp.status_code == 200:
+                data = resp.json()
+                messagebox.showinfo("Status", str(data))
+            else:
+                messagebox.showerror("Status", f"Error {resp.status_code}: {resp.text}")
+        except Exception as e:
+            messagebox.showerror("Status", str(e))
+
+    def display_logs(self, text):
+        self.log_text.configure(state=tk.NORMAL)
+        self.log_text.delete(1.0, tk.END)
+        self.log_text.insert(tk.END, text)
+        self.log_text.configure(state=tk.DISABLED)
+
+    def poll_logs(self):
+        hwid = self.hwid_var.get().strip()
+        if hwid:
+            self.load_logs(hwid)
+        self.root.after(5000, self.poll_logs)
+
+if __name__ == "__main__":
+    EXDApp()

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,7 @@
+services:
+  - type: web
+    name: fireguard-api
+    env: python
+    plan: free
+    startCommand: gunicorn server:app
+    buildCommand: pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ plyer
 ttkbootstrap
 requests
 packaging
+flask
+pymongo
+pyjwt
+werkzeug

--- a/server.py
+++ b/server.py
@@ -1,0 +1,136 @@
+from flask import Flask, request, jsonify
+from pymongo import MongoClient
+from werkzeug.security import generate_password_hash, check_password_hash
+import jwt
+import datetime
+import os
+from functools import wraps
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'changeme')
+MONGO_URI = os.environ.get('MONGO_URI', 'mongodb://localhost:27017/fireguard')
+client = MongoClient(MONGO_URI)
+db = client.get_default_database()
+
+users = db['users']
+logs = db['logs']
+scans = db['scans']
+violations = db['violations']
+
+LATEST_VERSION = os.environ.get('LATEST_VERSION', '0.1.0')
+
+
+def generate_token(user_id):
+    payload = {
+        'user_id': str(user_id),
+        'exp': datetime.datetime.utcnow() + datetime.timedelta(days=7)
+    }
+    return jwt.encode(payload, app.config['SECRET_KEY'], algorithm='HS256')
+
+
+def auth_required(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth = request.headers.get('Authorization', '')
+        if not auth.startswith('Bearer '):
+            return jsonify({'error': 'Missing token'}), 401
+        token = auth.split(' ', 1)[1]
+        try:
+            decoded = jwt.decode(token, app.config['SECRET_KEY'], algorithms=['HS256'])
+            request.user_id = decoded['user_id']
+        except jwt.PyJWTError:
+            return jsonify({'error': 'Invalid token'}), 401
+        return f(*args, **kwargs)
+    return decorated
+
+
+@app.post('/api/register')
+def register():
+    data = request.get_json() or {}
+    if not data.get('username') or not data.get('password'):
+        return jsonify({'error': 'missing fields'}), 400
+    if users.find_one({'username': data['username']}):
+        return jsonify({'error': 'exists'}), 400
+    hashed = generate_password_hash(data['password'])
+    user = {'username': data['username'], 'password': hashed, 'hwid': data.get('hwid'), 'banned': False}
+    res = users.insert_one(user)
+    token = generate_token(res.inserted_id)
+    return jsonify({'token': token})
+
+
+@app.post('/api/login')
+def login():
+    data = request.get_json() or {}
+    user = users.find_one({'username': data.get('username')})
+    if not user or not check_password_hash(user['password'], data.get('password', '')):
+        return jsonify({'error': 'invalid'}), 401
+    token = generate_token(user['_id'])
+    return jsonify({'token': token})
+
+
+@app.post('/api/log_error')
+@auth_required
+def log_error():
+    data = request.get_json() or {}
+    logs.insert_one({'hwid': data.get('hwid'), 'error': data.get('error'), 'ts': datetime.datetime.utcnow()})
+    return jsonify({'status': 'ok'})
+
+
+@app.post('/api/scan_report')
+@auth_required
+def scan_report():
+    data = request.get_json() or {}
+    scans.insert_one({'hwid': data.get('hwid'), 'file': data.get('file'), 'level': data.get('level'), 'score': data.get('score'), 'md5': data.get('md5'), 'ts': datetime.datetime.utcnow()})
+    return jsonify({'status': 'ok'})
+
+
+@app.post('/api/hwid_report')
+@auth_required
+def hwid_report():
+    data = request.get_json() or {}
+    logs.insert_one({'hwid': data.get('hwid'), 'info': 'hwid_report', 'file': data.get('file'), 'integrity': data.get('integrity'), 'ts': datetime.datetime.utcnow()})
+    return jsonify({'status': 'ok'})
+
+
+@app.get('/api/check_update')
+def check_update():
+    return jsonify({'latest': LATEST_VERSION})
+
+
+@app.get('/api/status')
+@auth_required
+def status():
+    hwid = request.args.get('hwid')
+    user = users.find_one({'hwid': hwid})
+    if not user:
+        return jsonify({'trusted': False}), 404
+    return jsonify({'trusted': not user.get('banned', False), 'banned': user.get('banned', False)})
+
+
+@app.post('/api/verify_integrity')
+@auth_required
+def verify_integrity():
+    data = request.get_json() or {}
+    # Placeholder integrity check
+    tampered = False
+    return jsonify({'tampered': tampered})
+
+
+@app.post('/api/report_violation')
+@auth_required
+def report_violation():
+    data = request.get_json() or {}
+    violations.insert_one({'hwid': data.get('hwid'), 'reason': data.get('reason'), 'ts': datetime.datetime.utcnow()})
+    return jsonify({'status': 'ok'})
+
+
+@app.get('/api/logs/<hwid>')
+@auth_required
+def get_logs(hwid):
+    data = list(logs.find({'hwid': hwid}).sort('ts', -1))
+    entries = [f"{d.get('ts')}: {d.get('error', d.get('info', ''))}" for d in data]
+    return jsonify({'logs': entries})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 5000)))


### PR DESCRIPTION
## Summary
- implement account-based authentication in `fireguard.py`
- include token in API helpers and add login/registration dialogs
- extend EXD admin tool with HWID log search and status checks
- document account login in README
- provide Flask backend `server.py` and Render deployment config

## Testing
- `python -m py_compile fireguard.py exd.py server.py`
- `pip install -r requirements.txt`
- `python exd.py` *(fails: no $DISPLAY)*
- `python server.py` *(starts development server)*

------
https://chatgpt.com/codex/tasks/task_e_6881c678a8b483288a313ad00e696f1b