### PR TITLE
Add user account tab and admin defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,34 @@ pyinstaller --onefile --noconsole fireguard.py
 ```
 
 The compiled `fireguard.exe` automatically checks GitHub releases on startup and prompts to download a newer version if available.
+
+### Account Login
+
+FireGuard now requires users to create a free account. On first launch you will
+be prompted to register or log in. After successful authentication a license
+token and username are stored locally and used for all API communication. The
+Account tab lets you view the current user and log out at any time.
+
+### Developer Tool EXD
+
+The EXD developer tool allows administrators to log in and monitor client activity.
+Default credentials are `admin:admin` when running the API locally.
+To run it locally:
+
+```bash
+python exd.py
+```
+
+The tool communicates with the backend API and requires valid admin credentials.
+
+
+### Backend API Deployment
+
+A simple Flask API implementation is provided in `server.py`. You can deploy it to [Render](https://render.com) using the included `render.yaml` configuration:
+
+```bash
+pip install -r requirements.txt
+python server.py  # local testing
+```
+
+On Render, create a new Web Service from this repo and it will automatically use `gunicorn server:app` to start the API.

--- a/exd.py
+++ b/exd.py
@@ -1,0 +1,116 @@
+# Developer tool for FireGuard - EXD
+import os
+import tkinter as tk
+import ttkbootstrap as ttkb
+from ttkbootstrap import ttk
+import requests
+from tkinter import messagebox
+
+API_URL = os.environ.get("API_URL", "http://localhost:5000")
+
+class EXDApp:
+    def __init__(self):
+        self.token = None
+        self.root = ttkb.Window(title="EXD Developer Tool")
+        self.create_login_ui()
+        self.root.mainloop()
+
+    def create_login_ui(self):
+        self.clear_root()
+        frm = ttk.Frame(self.root, padding=20)
+        frm.pack(expand=True)
+
+        ttk.Label(frm, text="Username").grid(row=0, column=0, sticky=tk.W, pady=5)
+        self.username_var = tk.StringVar(value="admin")
+        ttk.Entry(frm, textvariable=self.username_var, width=30).grid(row=0, column=1)
+
+        ttk.Label(frm, text="Password").grid(row=1, column=0, sticky=tk.W, pady=5)
+        self.password_var = tk.StringVar(value="admin")
+        ttk.Entry(frm, textvariable=self.password_var, show="*", width=30).grid(row=1, column=1)
+
+        ttk.Button(frm, text="Login", command=self.login).grid(row=2, column=0, columnspan=2, pady=10)
+
+    def clear_root(self):
+        for widget in self.root.winfo_children():
+            widget.destroy()
+
+    def login(self):
+        user = self.username_var.get()
+        password = self.password_var.get()
+        try:
+            resp = requests.post(f"{API_URL}/api/login", json={"username": user, "password": password}, timeout=5)
+            if resp.status_code == 200:
+                self.token = resp.json().get("token")
+                self.create_main_ui()
+            else:
+                messagebox.showerror("Login Failed", f"Status: {resp.status_code}\n{resp.text}")
+        except Exception as e:
+            messagebox.showerror("Login Error", str(e))
+
+    def create_main_ui(self):
+        self.clear_root()
+        self.root.geometry("600x400")
+        top = ttk.Frame(self.root, padding=10)
+        top.pack(fill=tk.X)
+
+        self.hwid_var = tk.StringVar()
+        ttk.Entry(top, textvariable=self.hwid_var, width=40).pack(side=tk.LEFT, padx=5)
+        ttk.Button(top, text="Fetch Logs", command=self.fetch_logs).pack(side=tk.LEFT)
+        ttk.Button(top, text="Check Status", command=self.check_status).pack(side=tk.LEFT, padx=5)
+        ttk.Button(top, text="Logout", command=self.create_login_ui).pack(side=tk.RIGHT)
+
+        self.log_text = tk.Text(self.root, state=tk.DISABLED)
+        self.log_text.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+        self.poll_logs()
+
+    def fetch_logs(self):
+        hwid = self.hwid_var.get().strip()
+        if not hwid:
+            messagebox.showerror("Error", "Enter HWID")
+            return
+        self.load_logs(hwid)
+
+    def load_logs(self, hwid: str):
+        if not self.token:
+            return
+        headers = {"Authorization": f"Bearer {self.token}"}
+        try:
+            resp = requests.get(f"{API_URL}/api/logs/{hwid}", headers=headers, timeout=5)
+            if resp.status_code == 200:
+                data = resp.json()
+                self.display_logs("\n".join(data.get("logs", [])))
+            else:
+                self.display_logs(f"Error {resp.status_code}: {resp.text}")
+        except Exception as e:
+            self.display_logs(f"Request error: {e}")
+
+    def check_status(self):
+        hwid = self.hwid_var.get().strip()
+        if not hwid or not self.token:
+            return
+        headers = {"Authorization": f"Bearer {self.token}"}
+        try:
+            resp = requests.get(f"{API_URL}/api/status", params={"hwid": hwid}, headers=headers, timeout=5)
+            if resp.status_code == 200:
+                data = resp.json()
+                messagebox.showinfo("Status", str(data))
+            else:
+                messagebox.showerror("Status", f"Error {resp.status_code}: {resp.text}")
+        except Exception as e:
+            messagebox.showerror("Status", str(e))
+
+    def display_logs(self, text):
+        self.log_text.configure(state=tk.NORMAL)
+        self.log_text.delete(1.0, tk.END)
+        self.log_text.insert(tk.END, text)
+        self.log_text.configure(state=tk.DISABLED)
+
+    def poll_logs(self):
+        hwid = self.hwid_var.get().strip()
+        if hwid:
+            self.load_logs(hwid)
+        self.root.after(5000, self.poll_logs)
+
+if __name__ == "__main__":
+    EXDApp()

--- a/fireguard.py
+++ b/fireguard.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 import tkinter as tk
 from tkinter import filedialog, messagebox
 from tkinter.scrolledtext import ScrolledText
@@ -39,6 +40,96 @@ VERSION = "0.1.0"
 GITHUB_REPO = "TheMich157/-FireGuard-Antivirus"
 LOG_PATH = "fireguard.log"
 THREAT_THRESHOLD = 3
+API_URL = "https://example.com"  # TODO: replace with real backend URL
+
+LICENSE_FILE = "license.json"
+TOKEN = None
+USERNAME = None
+
+def get_hwid() -> str:
+    """Return a simple hardware ID based on MAC address."""
+    try:
+        import uuid
+        return hashlib.md5(str(uuid.getnode()).encode()).hexdigest()
+    except Exception:
+        return "unknown"
+
+HWID = get_hwid()
+
+def load_token():
+    """Load stored token and username from disk if present."""
+    global TOKEN, USERNAME
+    try:
+        with open(LICENSE_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            TOKEN = data.get("token")
+            USERNAME = data.get("username")
+    except Exception:
+        TOKEN = None
+        USERNAME = None
+
+def save_token(token: str, username: str):
+    """Persist token and username for future sessions."""
+    global TOKEN, USERNAME
+    TOKEN = token
+    USERNAME = username
+    try:
+        with open(LICENSE_FILE, "w", encoding="utf-8") as f:
+            json.dump({"token": token, "username": username}, f)
+    except Exception:
+        pass
+
+def logout_user():
+    """Clear stored token."""
+    global TOKEN, USERNAME
+    TOKEN = None
+    USERNAME = None
+    try:
+        if os.path.exists(LICENSE_FILE):
+            os.remove(LICENSE_FILE)
+    except Exception:
+        pass
+
+def register_user(username: str, password: str) -> bool:
+    r = api_post("/api/register", {"username": username, "password": password, "hwid": HWID})
+    if isinstance(r, requests.Response) and r.ok:
+        tok = r.json().get("token")
+        if tok:
+            save_token(tok, username)
+            return True
+    return False
+
+def login_user(username: str, password: str) -> bool:
+    r = api_post("/api/login", {"username": username, "password": password, "hwid": HWID})
+    if isinstance(r, requests.Response) and r.ok:
+        tok = r.json().get("token")
+        if tok:
+            save_token(tok, username)
+            return True
+    return False
+
+def api_post(endpoint: str, data: dict):
+    """Helper to POST JSON data to the backend API."""
+    headers = {}
+    if TOKEN:
+        headers["Authorization"] = f"Bearer {TOKEN}"
+    try:
+        return requests.post(
+            f"{API_URL}{endpoint}", json=data, headers=headers, timeout=5
+        )
+    except Exception:
+        return None
+
+def api_get(endpoint: str, params: dict | None = None):
+    headers = {}
+    if TOKEN:
+        headers["Authorization"] = f"Bearer {TOKEN}"
+    try:
+        return requests.get(
+            f"{API_URL}{endpoint}", params=params, headers=headers, timeout=5
+        )
+    except Exception:
+        return None
 
 # Possible risks when using this program:
 # - Running unknown files may damage your system.
@@ -244,6 +335,40 @@ def classify_score(score):
         return "Medium"
     return "Low"
 
+def send_error_log(msg: str):
+    api_post("/api/log_error", {"hwid": HWID, "error": msg})
+
+def send_scan_report(file: str, level: str, score: int, md5: str):
+    api_post(
+        "/api/scan_report",
+        {"hwid": HWID, "file": file, "level": level, "score": score, "md5": md5},
+    )
+
+def verify_integrity():
+    """Send file hash to server and exit if tampered."""
+    try:
+        with open(__file__, "rb") as f:
+            hash_ = hashlib.md5(f.read()).hexdigest()
+        r = api_post("/api/verify_integrity", {"hwid": HWID, "hash": hash_})
+        if isinstance(r, requests.Response) and r.ok:
+            data = r.json()
+            if data.get("tampered"):
+                kill_switch("Integrity failure")
+    except Exception:
+        pass
+
+def check_status():
+    resp = api_get("/api/status", {"hwid": HWID})
+    if resp is not None and resp.status_code == 200:
+        data = resp.json()
+        if data.get("banned"):
+            kill_switch("User banned")
+
+def kill_switch(reason: str):
+    api_post("/api/report_violation", {"hwid": HWID, "reason": reason})
+    messagebox.showerror("FireGuard", f"Application disabled: {reason}")
+    sys.exit(1)
+
 def run_in_real_sandbox(path):
     try:
         temp_dir = tempfile.mkdtemp(prefix="sandbox_")
@@ -323,6 +448,9 @@ class FireGuardApp:
         self.lang = 'en'
         self.theme = 'flatly'
         self.style.theme_use(self.theme)
+        self.authenticate()
+        check_status()
+        verify_integrity()
         FireGuardApp.check_for_updates_gui = check_for_updates_gui
         icon_path = os.path.join(os.path.dirname(__file__), "fireguard_favicon.ico")
         if os.path.exists(icon_path):
@@ -339,9 +467,11 @@ class FireGuardApp:
         self.notebook = ttk.Notebook(self.root)
         self.scan_tab = ttk.Frame(self.notebook)
         self.settings_tab = ttk.Frame(self.notebook)
+        self.profile_tab = ttk.Frame(self.notebook)
         self.notebook.pack(fill="both", expand=True)
         self.notebook.add(self.scan_tab, text=LANGUAGES[self.lang]['scan_tab'])
         self.notebook.add(self.settings_tab, text=LANGUAGES[self.lang]['settings_tab'])
+        self.notebook.add(self.profile_tab, text="Account")
 
         self.text = ScrolledText(self.scan_tab, wrap="word", bg="black", fg="lime", insertbackground="lime")
         self.text.pack(fill="both", expand=True)
@@ -409,6 +539,11 @@ class FireGuardApp:
         self.btn_open_quarantine = ttk.Button(self.toolbar, command=self.open_quarantine)
         self.btn_open_quarantine.pack(side="right")
 
+        # account tab
+        self.account_label = ttk.Label(self.profile_tab, text="")
+        self.account_label.pack(pady=10)
+        ttk.Button(self.profile_tab, text="Logout", command=self.logout_action).pack()
+
         self.apply_language()
 
         self.monitoring = False
@@ -416,9 +551,60 @@ class FireGuardApp:
         self.stop_event = threading.Event()
         patterns.update(load_patterns_from_file())
         self.log_imports()
+        self.update_account_label()
+
+    def authenticate(self):
+        load_token()
+        if TOKEN:
+            self.update_account_label()
+            return
+        dialog = tk.Toplevel(self.root)
+        dialog.title("FireGuard Login")
+        ttk.Label(dialog, text="Username").grid(row=0, column=0, pady=5, sticky=tk.W)
+        user_var = tk.StringVar()
+        ttk.Entry(dialog, textvariable=user_var, width=30).grid(row=0, column=1)
+        ttk.Label(dialog, text="Password").grid(row=1, column=0, pady=5, sticky=tk.W)
+        pass_var = tk.StringVar()
+        ttk.Entry(dialog, textvariable=pass_var, show="*", width=30).grid(row=1, column=1)
+
+        def do_login():
+            if login_user(user_var.get(), pass_var.get()):
+                dialog.destroy()
+            else:
+                messagebox.showerror("Login", "Failed to login")
+
+        def do_register():
+            if register_user(user_var.get(), pass_var.get()):
+                messagebox.showinfo("Register", "Account created")
+                dialog.destroy()
+            else:
+                messagebox.showerror("Register", "Registration failed")
+
+        ttk.Button(dialog, text="Login", command=do_login).grid(row=2, column=0, pady=10)
+        ttk.Button(dialog, text="Register", command=do_register).grid(row=2, column=1)
+        dialog.transient(self.root)
+        dialog.grab_set()
+        self.root.wait_window(dialog)
+        self.update_account_label()
+
+    def logout_action(self):
+        if messagebox.askyesno("Logout", "Sign out from this device?"):
+            logout_user()
+            self.authenticate()
+
+    def update_account_label(self):
+        if USERNAME:
+            self.account_label.config(text=f"Logged in as {USERNAME}")
+        else:
+            self.account_label.config(text="Not logged in")
 
     def run_in_thread(self, func, *args):
-        threading.Thread(target=func, args=args, daemon=True).start()
+        def wrapper():
+            try:
+                func(*args)
+            except Exception as e:
+                send_error_log(str(e))
+        threading.Thread(target=wrapper, daemon=True).start()
 
     def log(self, msg):
         self.text.insert("end", msg + "\n")
@@ -429,6 +615,7 @@ class FireGuardApp:
                 f.write(msg + "\n")
         except Exception:
             pass
+        send_scan_report("log", "info", 0, "") if msg else None
 
     def log_imports(self):
         self.log("[✓] Načítané moduly:")
@@ -447,6 +634,7 @@ class FireGuardApp:
         t = LANGUAGES[self.lang]
         self.notebook.tab(0, text=t['scan_tab'])
         self.notebook.tab(1, text=t['settings_tab'])
+        self.notebook.tab(2, text='Account')
         self.save_patterns_btn.config(text=t['save_patterns'])
         self.lbl_language.config(text=t['language'])
         self.lbl_theme.config(text=t['theme'])
@@ -476,6 +664,7 @@ class FireGuardApp:
             self.run_in_thread(self.scan_directory, extract_to)
         else:
             self.log(f"[ERROR] Extrakcia zlyhala: {output}")
+            send_error_log(output)
 
     def scan_file(self):
         path = filedialog.askopenfilename(filetypes=[("Súbory", "*.*")])
@@ -504,6 +693,7 @@ class FireGuardApp:
             messagebox.showinfo("Vzory", "Vzory uložené.")
         except Exception as e:
             messagebox.showerror("Vzory", f"Chyba: {e}")
+            send_error_log(str(e))
 
     def clear_log(self):
         self.text.delete("1.0", tk.END)
@@ -524,6 +714,7 @@ class FireGuardApp:
                 subprocess.Popen(['xdg-open', qdir])
         except Exception:
             messagebox.showinfo('Quarantine', qdir)
+            send_error_log('open_quarantine_failed')
 
     def scan_single(self, path):
         file = os.path.basename(path)
@@ -545,7 +736,11 @@ class FireGuardApp:
                 qdir = os.path.join(os.getcwd(), "quarantine")
                 os.makedirs(qdir, exist_ok=True)
                 shutil.move(path, os.path.join(qdir, file))
+                send_scan_report(file, level, score, md5)
                 return
+            send_scan_report(file, level, score, md5)
+        else:
+            send_scan_report(file, "Clean", score, md5)
         if file.endswith(".exe") or file.endswith(".dll"):
             for line in analyze_exe_core(path):
                 self.log(line)
@@ -587,6 +782,7 @@ class FireGuardApp:
     def _behavior_task(self, path):
         for line in scan_file_behavior(path):
             self.log(line)
+            send_scan_report(os.path.basename(path), "behavior", 0, "")
 
     def run_sandbox(self):
         path = filedialog.askopenfilename(filetypes=[("Executable", "*.exe")])
@@ -600,11 +796,13 @@ class FireGuardApp:
                 self.monitoring = True
                 self.log(f"[✓] Spustený real-time monitoring priečinka: {folder}")
                 self.start_monitoring(folder)
+                send_scan_report("monitor", "start", 0, "")
         else:
             self.observer.stop()
             self.observer.join()
             self.monitoring = False
             self.log("[•] Real-time monitoring ukončený.")
+            send_scan_report("monitor", "stop", 0, "")
 
     def start_monitoring(self, folder):
         class Handler(FileSystemEventHandler):
@@ -613,6 +811,7 @@ class FireGuardApp:
                     return
                 self.log(f"[!] Zistený nový súbor: {event.src_path}")
                 self.run_in_thread(self.scan_directory, event.src_path)
+                send_scan_report("monitor", "created", 0, "")
 
         self.observer = Observer()
         self.observer.schedule(Handler(), folder, recursive=True)

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,7 @@
+services:
+  - type: web
+    name: fireguard-api
+    env: python
+    plan: free
+    startCommand: gunicorn server:app
+    buildCommand: pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ plyer
 ttkbootstrap
 requests
 packaging
+flask
+pymongo
+pyjwt
+werkzeug

--- a/server.py
+++ b/server.py
@@ -1,0 +1,151 @@
+from flask import Flask, request, jsonify
+from pymongo import MongoClient
+from werkzeug.security import generate_password_hash, check_password_hash
+import jwt
+import datetime
+import os
+from functools import wraps
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'changeme')
+MONGO_URI = os.environ.get('MONGO_URI', 'mongodb://localhost:27017/fireguard')
+client = MongoClient(MONGO_URI, serverSelectionTimeoutMS=2000)
+db = client.get_default_database()
+
+users = db['users']
+logs = db['logs']
+scans = db['scans']
+violations = db['violations']
+
+def init_db():
+    users.create_index('username', unique=True)
+    users.create_index('hwid', unique=True, sparse=True)
+    if not users.find_one({'username': 'admin'}):
+        admin_pass = os.environ.get('ADMIN_PASS', 'admin')
+        hashed = generate_password_hash(admin_pass)
+        users.insert_one({'username': 'admin', 'password': hashed, 'role': 'admin', 'banned': False})
+
+init_db()
+
+LATEST_VERSION = os.environ.get('LATEST_VERSION', '0.1.0')
+
+
+def generate_token(user_id):
+    payload = {
+        'user_id': str(user_id),
+        'exp': datetime.datetime.utcnow() + datetime.timedelta(days=7)
+    }
+    return jwt.encode(payload, app.config['SECRET_KEY'], algorithm='HS256')
+
+
+def auth_required(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth = request.headers.get('Authorization', '')
+        if not auth.startswith('Bearer '):
+            return jsonify({'error': 'Missing token'}), 401
+        token = auth.split(' ', 1)[1]
+        try:
+            decoded = jwt.decode(token, app.config['SECRET_KEY'], algorithms=['HS256'])
+            request.user_id = decoded['user_id']
+        except jwt.PyJWTError:
+            return jsonify({'error': 'Invalid token'}), 401
+        return f(*args, **kwargs)
+    return decorated
+
+
+@app.post('/api/register')
+def register():
+    data = request.get_json() or {}
+    if not data.get('username') or not data.get('password'):
+        return jsonify({'error': 'missing fields'}), 400
+    if users.find_one({'username': data['username']}):
+        return jsonify({'error': 'exists'}), 400
+    hashed = generate_password_hash(data['password'])
+    user = {'username': data['username'], 'password': hashed, 'hwid': data.get('hwid'), 'banned': False}
+    res = users.insert_one(user)
+    token = generate_token(res.inserted_id)
+    return jsonify({'token': token})
+
+
+@app.post('/api/login')
+def login():
+    data = request.get_json() or {}
+    user = users.find_one({'username': data.get('username')})
+    if not user or not check_password_hash(user['password'], data.get('password', '')):
+        return jsonify({'error': 'invalid'}), 401
+    hwid = data.get('hwid')
+    if user.get('hwid') and hwid and user['hwid'] != hwid:
+        return jsonify({'error': 'hwid mismatch'}), 403
+    if hwid and not user.get('hwid'):
+        users.update_one({'_id': user['_id']}, {'$set': {'hwid': hwid}})
+    token = generate_token(user['_id'])
+    return jsonify({'token': token})
+
+
+@app.post('/api/log_error')
+@auth_required
+def log_error():
+    data = request.get_json() or {}
+    logs.insert_one({'hwid': data.get('hwid'), 'error': data.get('error'), 'ts': datetime.datetime.utcnow()})
+    return jsonify({'status': 'ok'})
+
+
+@app.post('/api/scan_report')
+@auth_required
+def scan_report():
+    data = request.get_json() or {}
+    scans.insert_one({'hwid': data.get('hwid'), 'file': data.get('file'), 'level': data.get('level'), 'score': data.get('score'), 'md5': data.get('md5'), 'ts': datetime.datetime.utcnow()})
+    return jsonify({'status': 'ok'})
+
+
+@app.post('/api/hwid_report')
+@auth_required
+def hwid_report():
+    data = request.get_json() or {}
+    logs.insert_one({'hwid': data.get('hwid'), 'info': 'hwid_report', 'file': data.get('file'), 'integrity': data.get('integrity'), 'ts': datetime.datetime.utcnow()})
+    return jsonify({'status': 'ok'})
+
+
+@app.get('/api/check_update')
+def check_update():
+    return jsonify({'latest': LATEST_VERSION})
+
+
+@app.get('/api/status')
+@auth_required
+def status():
+    hwid = request.args.get('hwid')
+    user = users.find_one({'hwid': hwid})
+    if not user:
+        return jsonify({'trusted': False}), 404
+    return jsonify({'trusted': not user.get('banned', False), 'banned': user.get('banned', False)})
+
+
+@app.post('/api/verify_integrity')
+@auth_required
+def verify_integrity():
+    data = request.get_json() or {}
+    # Placeholder integrity check
+    tampered = False
+    return jsonify({'tampered': tampered})
+
+
+@app.post('/api/report_violation')
+@auth_required
+def report_violation():
+    data = request.get_json() or {}
+    violations.insert_one({'hwid': data.get('hwid'), 'reason': data.get('reason'), 'ts': datetime.datetime.utcnow()})
+    return jsonify({'status': 'ok'})
+
+
+@app.get('/api/logs/<hwid>')
+@auth_required
+def get_logs(hwid):
+    data = list(logs.find({'hwid': hwid}).sort('ts', -1))
+    entries = [f"{d.get('ts')}: {d.get('error', d.get('info', ''))}" for d in data]
+    return jsonify({'logs': entries})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 5000)))


### PR DESCRIPTION
## Summary
- persist username in saved token and add logout helper
- include new Account tab in FireGuard with logout button
- prepopulate EXD login with `admin` credentials
- initialize admin user in API and create DB indexes
- mention account tab and default admin login in README

## Testing
- `python -m py_compile fireguard.py exd.py server.py`
- `pip install -r requirements.txt`
- `python exd.py` *(fails: no $DISPLAY)*
- `python server.py` *(fails: ServerSelectionTimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_6881c678a8b483288a313ad00e696f1b