### PR TITLE
Improve UI and add homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 FireGuard Antivirus is a Python desktop application that performs static and behavioral malware analysis. A small Flask backend manages user accounts, logs, and version updates. An optional developer tool (**EXD**) lets admins review clients, push updates and inspect logs.
 
+You can try the hosted API at [wsl-agjq.onrender.com](https://wsl-agjq.onrender.com/).
+
 ---
 
 ## Features

--- a/exd.py
+++ b/exd.py
@@ -69,8 +69,12 @@ class EXDApp:
             self.clients_tree.heading(col, text=col.title())
         self.clients_tree.pack(fill=tk.X, padx=10, pady=10)
 
-        self.log_text = tk.Text(self.root, state=tk.DISABLED, height=10)
+        self.log_text = tk.Text(self.root, height=10)
         self.log_text.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+        self.log_text.bind("<Key>", lambda e: "break")
+
+        copy_btn = ttk.Button(top, text="Copy Logs", command=self.copy_logs)
+        copy_btn.pack(side=tk.RIGHT)
 
         self.load_clients()
         self.poll_logs()
@@ -100,10 +104,12 @@ class EXDApp:
             self.display_logs(f"Request error: {e}")
 
     def display_logs(self, text):
-        self.log_text.configure(state=tk.NORMAL)
         self.log_text.delete(1.0, tk.END)
         self.log_text.insert(tk.END, text)
-        self.log_text.configure(state=tk.DISABLED)
+
+    def copy_logs(self):
+        self.root.clipboard_clear()
+        self.root.clipboard_append(self.log_text.get("1.0", tk.END))
     def poll_logs(self):
         self.fetch_logs()
         self.log_job = self.root.after(5000, self.poll_logs)

--- a/fireguard.py
+++ b/fireguard.py
@@ -157,6 +157,7 @@ LANGUAGES = {
         'save_log': 'Save Log',
         'save_patterns': 'Save Patterns',
         'open_quarantine': 'Open Quarantine',
+        'copy_log': 'Copy Log',
         'scan_tab': 'Scanning',
         'settings_tab': 'Settings',
         'language': 'Language',
@@ -176,6 +177,7 @@ LANGUAGES = {
         'save_log': 'Uložiť log',
         'save_patterns': 'Uložiť vzory',
         'open_quarantine': 'Otvoriť karanténu',
+        'copy_log': 'Kopírovať log',
         'scan_tab': 'Skenovanie',
         'settings_tab': 'Nastavenia',
         'language': 'Jazyk',
@@ -195,6 +197,7 @@ LANGUAGES = {
         'save_log': 'Uložit log',
         'save_patterns': 'Uložit vzory',
         'open_quarantine': 'Otevřít karanténu',
+        'copy_log': 'Kopírovat log',
         'scan_tab': 'Skenování',
         'settings_tab': 'Nastavení',
         'language': 'Jazyk',
@@ -214,6 +217,7 @@ LANGUAGES = {
         'save_log': 'Log speichern',
         'save_patterns': 'Muster speichern',
         'open_quarantine': 'Quarantäne öffnen',
+        'copy_log': 'Log kopieren',
         'scan_tab': 'Scan',
         'settings_tab': 'Einstellungen',
         'language': 'Sprache',
@@ -452,6 +456,7 @@ class FireGuardApp:
 
         self.text = ScrolledText(self.scan_tab, wrap="word", bg="black", fg="lime", insertbackground="lime")
         self.text.pack(fill="both", expand=True)
+        self.text.bind("<Key>", lambda e: "break")
 
         self.progress = ttk.Progressbar(self.scan_tab, mode="determinate")
         self.progress.pack(fill="x")
@@ -504,6 +509,8 @@ class FireGuardApp:
         self.btn_monitor.pack(side="left")
         self.btn_clear_log = ttk.Button(self.toolbar, command=self.clear_log)
         self.btn_clear_log.pack(side="right")
+        self.btn_copy_log = ttk.Button(self.toolbar, command=self.copy_log)
+        self.btn_copy_log.pack(side="right")
         self.btn_save_log = ttk.Button(self.toolbar, command=self.save_log)
         self.btn_save_log.pack(side="right")
         self.btn_update = ttk.Button(
@@ -664,6 +671,7 @@ class FireGuardApp:
         self.btn_sandbox.config(text='🧪 ' + t['sandbox_test'])
         self.btn_monitor.config(text='🟢 ' + t['monitor'])
         self.btn_clear_log.config(text='🧹 ' + t['clear_log'])
+        self.btn_copy_log.config(text='📋 ' + t['copy_log'])
         self.btn_save_log.config(text='💾 ' + t['save_log'])
         self.btn_open_quarantine.config(text='📂 ' + t['open_quarantine'])
 
@@ -713,6 +721,10 @@ class FireGuardApp:
 
     def clear_log(self):
         self.text.delete("1.0", tk.END)
+
+    def copy_log(self):
+        self.root.clipboard_clear()
+        self.root.clipboard_append(self.text.get("1.0", tk.END))
 
     def save_log(self):
         log_path = filedialog.asksaveasfilename(defaultextension=".txt")

--- a/server.py
+++ b/server.py
@@ -189,9 +189,16 @@ def admin_logout():
     return redirect(url_for('admin_login'))
 
 @app.route('/')
-def root_redirect():
-    """Redirect bare root to the admin login."""
-    return redirect(url_for('admin_login'))
+def home_page():
+    """Simple landing page for the API service."""
+    return render_template_string(
+        """
+        <h1>FireGuard Antivirus</h1>
+        <p>Welcome to the FireGuard API server.</p>
+        <p>Visit the <a href='/admin'>admin dashboard</a> for management.</p>
+        <p>Project homepage: <a href='https://wsl-agjq.onrender.com/'>wsl-agjq.onrender.com</a></p>
+        """
+    )
 
 @app.route('/admin/api/<path:path>')
 @admin_login_required


### PR DESCRIPTION
## Summary
- add simple home page route referencing wsl-agjq.onrender.com
- tweak EXD logs widget so text cannot be edited and add copy button
- make FireGuard logs read-only and add copy button
- mention hosted API in README

## Testing
- `python -m py_compile server.py fireguard.py exd.py`

------
https://chatgpt.com/codex/tasks/task_e_6882248bcd3c8328a9c4a0bd0b80d353