### PR TITLE
Add docs pages, UI styling, and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 FireGuard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -124,3 +124,6 @@ Every endpoint requires a `Bearer` token header except `/admin` and the registra
 ---
 
 FireGuard is a work in progress and should not be trusted as a full security solution. Use it for educational purposes only.
+
+## License
+This project is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/server.py
+++ b/server.py
@@ -21,6 +21,17 @@ import threading
 import time
 import requests
 
+# Simple CSS style used by rendered pages
+STYLE = """
+<style>
+body {font-family: Arial, sans-serif; background:#f0f2f5; margin:40px; color:#333;}
+h1, h2 {color:#d9534f;}
+table {border-collapse: collapse; width:100%;}
+th, td {padding:8px 12px; border:1px solid #ccc;}
+a {color:#0275d8; text-decoration:none;}
+</style>
+"""
+
 
 # Flask app setup
 app = Flask(__name__)
@@ -172,11 +183,11 @@ def admin_login():
             return redirect(url_for('admin_dashboard'))
         error = 'Invalid credentials'
     return render_template_string(
-        '''<form method="post">
+        STYLE + '''<form method="post" style="max-width:300px;margin:auto;">
             <h2>Admin Login</h2>
             <p style="color:red;">{{error}}</p>
-            <input name="username" placeholder="Username">
-            <input name="password" type="password" placeholder="Password">
+            <input name="username" placeholder="Username" style="width:100%;margin-bottom:10px;">
+            <input name="password" type="password" placeholder="Password" style="width:100%;margin-bottom:10px;">
             <button type="submit">Login</button>
         </form>''',
         error=error,
@@ -192,13 +203,29 @@ def admin_logout():
 def home_page():
     """Simple landing page for the API service."""
     return render_template_string(
-        """
+        STYLE + """
         <h1>FireGuard Antivirus</h1>
         <p>Welcome to the FireGuard API server.</p>
         <p>Visit the <a href='/admin'>admin dashboard</a> for management.</p>
+        <p>API reference: <a href='/docs'>/docs</a></p>
         <p>Project homepage: <a href='https://fireguard-antivirus.onrender.com/'>https://fireguard-antivirus.onrender.com</a></p>
         """
     )
+
+
+@app.route('/docs')
+def docs_index():
+    """List available API endpoints."""
+    routes = sorted(r.rule for r in app.url_map.iter_rules() if r.rule.startswith('/api/'))
+    links = ''.join(f"<li><a href='/docs{p}'>{p}</a></li>" for p in routes)
+    return render_template_string(STYLE + f"<h2>API Documentation</h2><ul>{links}</ul>")
+
+
+@app.route('/docs/api/<path:path>')
+@app.route('/docs/<path:path>')
+def docs_redirect(path):
+    """Redirect /docs/<endpoint> to the actual API endpoint."""
+    return redirect(f'/api/{path}')
 
 @app.route('/admin/api/<path:path>')
 @admin_login_required
@@ -240,9 +267,9 @@ def admin_dashboard():
             link = p
         rows += f'<tr><td>{link}</td><td style="color:{color}">{s}</td></tr>'
     return render_template_string(
-        f'''<h2>Server Status</h2>
+        STYLE + f'''<h2>Server Status</h2>
             <p>Registered users: {users_count}</p>
-            <table border="1" cellpadding="5">{rows}</table>
+            <table>{rows}</table>
             <a href="{{{{ url_for('admin_logout') }}}}">Logout</a>'''
     )
 


### PR DESCRIPTION
## Summary
- add MIT license
- style the built-in HTML pages
- add documentation index with redirects to the API
- mention license in README

## Testing
- `python -m py_compile server.py exd.py fireguard.py`

------
https://chatgpt.com/codex/tasks/task_e_6882272577a0832892a08b0ee8272923