### PR TITLE
replace token auth with license system

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can try the hosted API at [wsl-agjq.onrender.com](https://wsl-agjq.onrender.
    ```bash
    python fireguard.py
    ```
-   The first run asks you to register or log in. Credentials are stored in `license.json` and used for all API calls.
+   The first run asks you to register or log in. A license key is generated during registration and saved to `license.json`. On login, the key is copied to your clipboard for convenience.
 
 ### Building a Windows executable
 ```bash
@@ -56,6 +56,8 @@ API_URL=https://myserver.com python fireguard.py
    - `ADMIN_PASS` – initial admin password
    - `LATEST_VERSION` – current client version tag
    - `LATEST_BINARY` – path to the latest `.exe` to serve via `/release`
+   - `DISCORD_BOT_TOKEN` – bot token for license notifications
+   - `DISCORD_CHANNEL_ID` – channel ID for license notifications
 3. Start locally with:
    ```bash
    python server.py
@@ -90,10 +92,8 @@ The backend exposes `/admin` – a simple page listing API routes with a green/r
 | `POST /api/login` | authenticate user |
 | `GET /api/me` | return current account info |
 | `POST /api/change_password` | change logged in user's password |
-| `POST /api/logout` | invalidate token (optional) |
 | `POST /api/reset_password_request` | start a password reset |
 | `POST /api/reset_password` | complete password reset |
-| `POST /api/refresh_token` | renew JWT |
 | `GET /api/check_update` | get latest client version |
 | `POST /api/set_version` | set latest version (admin) |
 | `GET /api/download_update` | download newest binary |
@@ -118,8 +118,10 @@ The backend exposes `/admin` – a simple page listing API routes with a green/r
 | `POST /api/analyze_file` | upload file for scoring |
 | `GET /api/get_threat_score/<md5>` | query score by hash |
 | `POST /api/submit_feedback` | submit false‑positive feedback |
+| `POST /api/control/restart` | restart the server (admin) |
+| `POST /api/control/shutdown` | shutdown the server (admin) |
 
-Every endpoint requires a `Bearer` token header except `/admin` and the registration/login routes.
+Every endpoint requires an `X-License` header except `/admin` and the registration/login routes.
 
 ---
 

--- a/exd.py
+++ b/exd.py
@@ -10,7 +10,7 @@ API_URL = os.environ.get("API_URL", "https://fireguard-antivirus.onrender.com")
 
 class EXDApp:
     def __init__(self):
-        self.token = None
+        self.license = None
         self.log_job = None
         self.root = ttkb.Window(title="EXD Developer Tool")
         self.create_login_ui()
@@ -44,7 +44,7 @@ class EXDApp:
         try:
             resp = requests.post(f"{API_URL}/api/login", json={"username": user, "password": password}, timeout=5)
             if resp.status_code == 200:
-                self.token = resp.json().get("token")
+                self.license = resp.json().get("license")
                 self.create_main_ui()
             else:
                 messagebox.showerror("Login Failed", f"Status: {resp.status_code}\n{resp.text}")
@@ -91,9 +91,9 @@ class EXDApp:
         self.load_logs(hwid)
 
     def load_logs(self, hwid=None):
-        if not self.token:
+        if not self.license:
             return
-        headers = {"Authorization": f"Bearer {self.token}"}
+        headers = {"X-License": self.license}
         params = {"hwid": hwid} if hwid else {}
         try:
             resp = requests.get(
@@ -118,9 +118,9 @@ class EXDApp:
         self.fetch_logs()
         self.log_job = self.root.after(5000, self.poll_logs)
     def load_clients(self):
-        if not self.token:
+        if not self.license:
             return
-        headers = {"Authorization": f"Bearer {self.token}"}
+        headers = {"X-License": self.license}
         try:
             resp = requests.get(f"{API_URL}/api/clients", headers=headers, timeout=5)
             if resp.status_code == 200:
@@ -134,7 +134,7 @@ class EXDApp:
             messagebox.showerror("Error", str(e))
     
     def license_check(self):
-        if not self.token:
+        if not self.license:
             return
         item = self.clients_tree.selection()
         if not item:
@@ -144,7 +144,7 @@ class EXDApp:
         key = simpledialog.askstring("License Check", "Enter license key:")
         if not key:
             return
-        headers = {"Authorization": f"Bearer {self.token}"}
+        headers = {"X-License": self.license}
         try:
             resp = requests.post(
                 f"{API_URL}/api/license_check",
@@ -164,7 +164,7 @@ class EXDApp:
             messagebox.showerror("Error", str(e))
 
     def add_license(self):
-        if not self.token:
+        if not self.license:
             return
         item = self.clients_tree.selection()
         if not item:
@@ -174,7 +174,7 @@ class EXDApp:
         payload = {"username": username}
         if key:
             payload["license"] = key
-        headers = {"Authorization": f"Bearer {self.token}"}
+        headers = {"X-License": self.license}
         try:
             resp = requests.post(f"{API_URL}/api/add_license", headers=headers, json=payload, timeout=5)
             if resp.status_code == 200:
@@ -186,13 +186,13 @@ class EXDApp:
             messagebox.showerror("Error", str(e))
 
     def remove_license(self):
-        if not self.token:
+        if not self.license:
             return
         item = self.clients_tree.selection()
         if not item:
             return
         username = self.clients_tree.item(item[0]).get("values")[0]
-        headers = {"Authorization": f"Bearer {self.token}"}
+        headers = {"X-License": self.license}
         try:
             resp = requests.post(
                 f"{API_URL}/api/remove_license",
@@ -208,13 +208,13 @@ class EXDApp:
             messagebox.showerror("Error", str(e))
 
     def ban_hwid(self):
-        if not self.token:
+        if not self.license:
             return
         item = self.clients_tree.selection()
         if not item:
             return
         hwid = self.clients_tree.item(item[0]).get("values")[1]
-        headers = {"Authorization": f"Bearer {self.token}"}
+        headers = {"X-License": self.license}
         try:
             resp = requests.post(
                 f"{API_URL}/api/ban_hwid",
@@ -256,12 +256,12 @@ class EXDApp:
         self.root.mainloop()
 
     def push_update(self):
-        if not self.token:
+        if not self.license:
             return
         version = simpledialog.askstring("Push Update", "New version tag:")
         if not version:
             return
-        headers = {"Authorization": f"Bearer {self.token}"}
+        headers = {"X-License": self.license}
         try:
             resp = requests.post(
                 f"{API_URL}/api/set_version",
@@ -277,7 +277,7 @@ class EXDApp:
             messagebox.showerror("Error", str(e))
 
     def toggle_ban(self):
-        if not self.token:
+        if not self.license:
             return
         item = self.clients_tree.selection()
         if not item:
@@ -287,7 +287,7 @@ class EXDApp:
             return
         username, hwid, banned = values[0], values[1], values[2]
         new_status = not banned
-        headers = {"Authorization": f"Bearer {self.token}"}
+        headers = {"X-License": self.license}
         try:
             resp = requests.post(
                 f"{API_URL}/api/set_banned",
@@ -303,7 +303,7 @@ class EXDApp:
             messagebox.showerror("Error", str(e))
 
     def remove_client(self):
-        if not self.token:
+        if not self.license:
             return
         item = self.clients_tree.selection()
         if not item:
@@ -314,7 +314,7 @@ class EXDApp:
         username, hwid = values[0], values[1]
         if not messagebox.askyesno("Remove", f"Remove {username}?"):
             return
-        headers = {"Authorization": f"Bearer {self.token}"}
+        headers = {"X-License": self.license}
         try:
             resp = requests.post(
                 f"{API_URL}/api/remove_user",

--- a/fireguard.py
+++ b/fireguard.py
@@ -36,7 +36,7 @@ import json
 import requests
 from packaging import version
 
-VERSION = "0.1.0"
+VERSION = "0.3.1"
 GITHUB_REPO = "TheMich157/-FireGuard-Antivirus"
 LOG_PATH = "fireguard.log"
 THREAT_THRESHOLD = 3
@@ -49,7 +49,6 @@ if not os.path.exists(LOG_PATH):
 # Default API URL, can be overridden by environment variable
 API_URL = os.environ.get("API_URL", "https://fireguard-antivirus.onrender.com")
 LICENSE_FILE = "license.json"
-TOKEN = None
 USERNAME = None
 LICENSE_KEY = None
 
@@ -63,28 +62,22 @@ def get_hwid() -> str:
 
 HWID = get_hwid()
 
-def load_token():
-    global TOKEN, USERNAME, LICENSE_KEY
+def load_credentials():
+    global USERNAME, LICENSE_KEY
     try:
         with open(LICENSE_FILE, "r", encoding="utf-8") as f:
            data = json.load(f)
-           TOKEN = data.get("token")
            USERNAME = data.get("username")
            LICENSE_KEY = data.get("license")
     except FileNotFoundError:
-        TOKEN = None
         USERNAME = None
         LICENSE_KEY = None
 
-def save_token(token: str, username: str, license_key: str | None = None):
-    global TOKEN, USERNAME, LICENSE_KEY
-    TOKEN = token
+def save_credentials(username: str, license_key: str):
+    global USERNAME, LICENSE_KEY
     USERNAME = username
-    if license_key is not None:
-        LICENSE_KEY = license_key
-    data = {"token": token, "username": username}
-    if LICENSE_KEY:
-        data["license"] = LICENSE_KEY
+    LICENSE_KEY = license_key
+    data = {"username": username, "license": license_key}
     try:
         with open(LICENSE_FILE, "w", encoding="utf-8") as f:
             json.dump(data, f)
@@ -92,24 +85,13 @@ def save_token(token: str, username: str, license_key: str | None = None):
         pass
 
 def logout_user():
-    """Clear stored token."""
-    global TOKEN, USERNAME, LICENSE_KEY
-    TOKEN = None
+    """Clear stored credentials."""
+    global USERNAME, LICENSE_KEY
     USERNAME = None
     LICENSE_KEY = None
     try:
         if os.path.exists(LICENSE_FILE):
             os.remove(LICENSE_FILE)
-    except Exception:
-        pass
-
-def save_token(token: str, username: str):
-    global TOKEN, USERNAME
-    TOKEN = token
-    USERNAME = username
-    try:
-        with open(LICENSE_FILE, "w", encoding="utf-8") as f:
-            json.dump({"token": token, "username": username}, f)
     except Exception:
         pass
 
@@ -119,18 +101,19 @@ def register_user(username: str, password: str) -> bool:
     r = api_post("/api/register", {"username": username, "password": password, "hwid": HWID})
     if isinstance(r, requests.Response) and r.ok:
         data = r.json()
-        tok = data.get("token")
-        if tok:
-            save_token(tok, username, data.get("license"))
+        lic = data.get("license")
+        if lic:
+            save_credentials(username, lic)
             return True
     return False
 
 def login_user(username: str, password: str) -> bool:
     r = api_post("/api/login", {"username": username, "password": password})
     if isinstance(r, requests.Response) and r.ok:
-        tok = r.json().get("token")
-        if tok:
-            save_token(tok, username)
+        data = r.json()
+        lic = data.get("license")
+        if lic:
+            save_credentials(username, lic)
             return True
     return False
 
@@ -139,8 +122,8 @@ def login_user(username: str, password: str) -> bool:
 def api_post(endpoint: str, data: dict):
     """Helper to POST JSON data to the backend API."""
     headers = {}
-    if TOKEN:
-        headers["Authorization"] = f"Bearer {TOKEN}"
+    if LICENSE_KEY:
+        headers["X-License"] = LICENSE_KEY
     try:
         return requests.post(
             f"{API_URL}{endpoint}", json=data, headers=headers, timeout=5
@@ -150,8 +133,8 @@ def api_post(endpoint: str, data: dict):
 
 def api_get(endpoint: str, params: dict | None = None):
     headers = {}
-    if TOKEN:
-        headers["Authorization"] = f"Bearer {TOKEN}"
+    if LICENSE_KEY:
+        headers["X-License"] = LICENSE_KEY
     try:
         return requests.get(
             f"{API_URL}{endpoint}", params=params, headers=headers, timeout=5
@@ -568,8 +551,8 @@ class FireGuardApp:
         self.update_account_label()
 
     def authenticate(self):
-        load_token()
-        if TOKEN:
+        load_credentials()
+        if LICENSE_KEY and USERNAME:
             self.update_account_label()
             return
         dialog = tk.Toplevel(self.root)
@@ -584,12 +567,19 @@ class FireGuardApp:
         def do_login():
             if login_user(user_var.get(), pass_var.get()):
                 dialog.destroy()
+                if LICENSE_KEY:
+                    self.root.clipboard_clear()
+                    self.root.clipboard_append(LICENSE_KEY)
+                    messagebox.showinfo("License", f"Your license: {LICENSE_KEY}\n(Copied to clipboard)")
                 self.check_license()
             else:
                 messagebox.showerror("Login", "Failed to login")
 
         def do_register():
             if register_user(user_var.get(), pass_var.get()):
+                if LICENSE_KEY:
+                    self.root.clipboard_clear()
+                    self.root.clipboard_append(LICENSE_KEY)
                 messagebox.showinfo("Register", f"Account created. License: {LICENSE_KEY}")
                 dialog.destroy()
             else:
@@ -878,12 +868,12 @@ class FireGuardApp:
         self.observer.start()
 
     def check_license(self):
-        if not TOKEN:
+        global LICENSE_KEY
+        if not LICENSE_KEY or not USERNAME:
             self.authenticate()
-        if not TOKEN:
+        if not LICENSE_KEY or not USERNAME:
             messagebox.showerror("FireGuard", "You must be logged in to use this feature.")
             return False
-        global LICENSE_KEY
         if not LICENSE_KEY:
             key = simpledialog.askstring("License", "Enter your license key:")
             if not key:
@@ -896,7 +886,7 @@ class FireGuardApp:
         data = r.json()
         if data.get("valid"):
             messagebox.showinfo("FireGuard", "Your license is valid.")
-            save_token(TOKEN, USERNAME, LICENSE_KEY)
+            save_credentials(USERNAME, LICENSE_KEY)
         else:
             messagebox.showwarning("FireGuard", "Your license is invalid or expired.")
             LICENSE_KEY = None


### PR DESCRIPTION
## Summary
- drop JWT token requirements in favor of license header
- send license notifications using a Discord bot
- update client and admin tool to use `X-License` header
- add admin endpoints to restart or shut down the server

## Testing
- `python -m py_compile fireguard.py server.py exd.py`


------
https://chatgpt.com/codex/tasks/task_e_68826349a28c8328b5b8e3743bf673d5