### PR TITLE
Add Discord bot and secure admin controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,24 @@ Run `python exd.py` to launch the admin toolkit. After logging in you can:
 - Toggle bans or remove users
 - Browse logs in real time
 
+## Discord Bot
+`bot.py` provides a small Discord bot with slash commands for notifying new
+licenses and remotely restarting or shutting down the server. Set the
+`DISCORD_BOT_TOKEN`, optional `ADMIN_LICENSE`, and `API_URL` environment
+variables. The server will launch the bot automatically if a token is present or
+you can run it manually with:
+
+```bash
+python bot.py
+```
+
 ---
 
 ## Admin Dashboard
-The backend exposes `/admin` – a simple page listing API routes with a green/red status indicator and the total user count. Use your EXD credentials to log in.
+The backend exposes `/admin` – a simple page listing API routes with a green/red
+status indicator and the total user count. After logging in you can restart or
+shut down the server and access helper pages to ban users, run the kill switch,
+check licenses or look up usernames.
 
 ---
 
@@ -103,8 +117,11 @@ The backend exposes `/admin` – a simple page listing API routes with a green/r
 | `POST /api/remove_user` | delete an account |
 | `POST /api/ban` | ban a user or HWID |
 | `POST /api/unban` | remove a ban |
+| `POST /api/ban_hwid` | ban by HWID |
 | `POST /api/set_banned` | toggle ban status |
 | `POST /api/unlink_hwid` | reset user's HWID |
+| `POST /api/find_username` | lookup username by license or HWID |
+| `GET /api/my_license` | current license status |
 | `POST /api/security/kill_switch` | force shutdown on a client |
 | `POST /api/security/flag_hwid` | mark HWID as suspicious |
 | `GET /api/activity_log` | admin activity history |

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,67 @@
+import os
+import requests
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+API_URL = os.environ.get("API_URL", "https://fireguard.aigenres.xyz")
+ADMIN_LICENSE = os.environ.get("ADMIN_LICENSE")
+TOKEN = os.environ.get("DISCORD_BOT_TOKEN")
+
+intents = discord.Intents.default()
+
+bot = commands.Bot(command_prefix="!", intents=intents)
+
+
+def post_api(path: str):
+    headers = {}
+    if ADMIN_LICENSE:
+        headers["X-License"] = ADMIN_LICENSE
+    try:
+        requests.post(f"{API_URL}{path}", headers=headers, timeout=5)
+        return True
+    except Exception:
+        return False
+
+
+@bot.event
+async def on_ready():
+    print(f"Logged in as {bot.user}")
+    try:
+        synced = await bot.tree.sync()
+        print(f"Synced {len(synced)} command(s)")
+    except Exception as e:
+        print("Sync failed", e)
+
+
+@bot.tree.command(name="license", description="Send license info")
+@app_commands.describe(username="Username", key="License key")
+async def license_cmd(interaction: discord.Interaction, username: str, key: str):
+    embed = discord.Embed(title="New License", color=0x2ecc71)
+    embed.add_field(name="User", value=username, inline=False)
+    embed.add_field(name="License", value=f"`{key}`", inline=False)
+    await interaction.response.send_message(embed=embed)
+
+
+@bot.tree.command(name="restart", description="Restart the FireGuard server")
+async def restart_cmd(interaction: discord.Interaction):
+    await interaction.response.defer(ephemeral=True)
+    if post_api("/api/control/restart"):
+        await interaction.followup.send("Server restart initiated.")
+    else:
+        await interaction.followup.send("Failed to contact server.")
+
+
+@bot.tree.command(name="shutdown", description="Shutdown the FireGuard server")
+async def shutdown_cmd(interaction: discord.Interaction):
+    await interaction.response.defer(ephemeral=True)
+    if post_api("/api/control/shutdown"):
+        await interaction.followup.send("Server shutdown initiated.")
+    else:
+        await interaction.followup.send("Failed to contact server.")
+
+
+if __name__ == "__main__":
+    if not TOKEN:
+        raise SystemExit("DISCORD_BOT_TOKEN missing")
+    bot.run(TOKEN)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ flask
 pymongo
 pyjwt
 werkzeug
+discord.py


### PR DESCRIPTION
## Summary
- introduce slash-command Discord bot
- restrict sensitive API routes to admin users
- add server control buttons to the admin dashboard
- document Discord bot and dashboard controls
- include `discord.py` dependency


------
https://chatgpt.com/codex/tasks/task_e_68834a68aaec83289b937feea38124b5